### PR TITLE
mbedtls createcertificate: fix length calculation

### DIFF
--- a/plugins/crypto/mbedtls/ua_mbedtls_create_certificate.c
+++ b/plugins/crypto/mbedtls/ua_mbedtls_create_certificate.c
@@ -195,7 +195,7 @@ UA_CreateCertificate(const UA_Logger *logger, const UA_String *subject,
         /* split into SAN type and value */
         sanType = strtok(subAlt, ":");
         sanValue = (char *)subjectAltName[i].data + strlen(sanType) + 1;
-        sanValueLength = strlen(sanValue);
+        sanValueLength = subjectAltName[i].length - strlen(sanType) - 1;
 
         if(sanType) {
             cur_tmp = (mbedtls_write_san_list*)mbedtls_calloc(1, sizeof(mbedtls_write_san_list));


### PR DESCRIPTION
In createcertificate, strlen() was used on a not null terminated string. This could result in using uninitialized memory for SAN attributes or even segfaults.